### PR TITLE
PLAT-1379: pin alpine to 2.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:2.19
 
 RUN apk --update --no-cache add git aws-cli
 


### PR DESCRIPTION
Due to [an issue](https://github.com/alpinelinux/docker-alpine/issues/396) with Python in the Docker Alpine v3 release, the `aws-cli` is not able to be installed without workarounds. The easiest solution for us is to pin to an older version of Alpine until a fix is released in v3.